### PR TITLE
Avoid SQL syntax error when `where` SQL part is empty

### DIFF
--- a/bp-groups/bp-groups-tag.php
+++ b/bp-groups/bp-groups-tag.php
@@ -205,7 +205,7 @@ class BP_Groups_Tag {
 			$this->tax_query = $tax_query->get_sql( 'g', 'id' );
 
 			$sql_parts['from']  = sprintf( 'FROM %1$s%2$s', $sql_parts['from'], $this->tax_query['join'] );
-			$sql_parts['where'] = sprintf( 'WHERE %1$s%2$s', $sql_parts['where'], $this->tax_query['where'] );
+			$sql_parts['where'] = sprintf( 'WHERE %1$s%2$s', empty($sql_parts['where']) ? '1=1' : $sql_parts['where'], $this->tax_query['where'] );
 
 			$query = join( ' ', (array) $sql_parts );
 		}

--- a/bp-groups/bp-groups-tag.php
+++ b/bp-groups/bp-groups-tag.php
@@ -224,7 +224,7 @@ class BP_Groups_Tag {
 			$sql = array(
 				'select' => 'SELECT COUNT(DISTINCT g.id)',
 				'from'   => sprintf( 'FROM %1$s%2$s', $sql_parts['from'], $this->tax_query['join'] ),
-				'where'  => sprintf( 'WHERE %1$s%2$s', $sql_parts['where'], $this->tax_query['where'] ),
+				'where'  => sprintf( 'WHERE %1$s%2$s', empty( $sql_parts['where'] ) ? '1=1' : $sql_parts['where'], $this->tax_query['where'] ),
 			);
 
 			$query = join( ' ', $sql );


### PR DESCRIPTION
Since the taxonomy query's `where` part always starts with " AND " we need to spit out `1=1` when the original query's `where` part is an empty string.